### PR TITLE
Stop responding to pushed messages

### DIFF
--- a/lib/protein/adapters/amqp_adapter/server.ex
+++ b/lib/protein/adapters/amqp_adapter/server.ex
@@ -68,7 +68,9 @@ defmodule Protein.AMQPAdapter.Server do
     server_mod = Keyword.fetch!(opts, :server_mod)
 
     {response, error} = try_process(payload, server_mod)
-    respond(response, chan, meta)
+
+    if should_respond(response, meta), do: respond(response, chan, meta)
+
     Basic.ack(chan, meta.delivery_tag)
 
     if error do
@@ -86,7 +88,10 @@ defmodule Protein.AMQPAdapter.Server do
       {"ESRV", {exception, stacktrace}}
   end
 
-  defp respond(nil, _chan, _meta), do: nil
+  defp should_respond(nil, _meta), do: false
+  defp should_respond(_response, %{reply_to: :undefined} = _meta), do: false
+  defp should_respond(_response, _meta), do: true
+
   defp respond(response, chan, meta) do
     %{
       correlation_id: correlation_id,


### PR DESCRIPTION
## Overview
Currently, when rpc server crashes with an unhandled error, it will try to send back an `"ESRV"` message. This occurs even if the message was pushed (thus there is no response channel and no correlation_id set) and client does not wait for the response. Responding to pushed message results in responding to channel `:undefined` with correlation_id set to `:undefined`

This pull request rewrites check whether the response should be sent or not. Unless `respond_to` meta key is set to something different than `:undefined`, protein will not try to send response as simply there is no use for that.