### PR TITLE
Add request metadata to logs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
 if Mix.env == :test do
-  config :logger, level: :info
+  config :logger, level: :warn
   config :protein, mocking_enabled: true
 end

--- a/lib/protein/apis/server_api.ex
+++ b/lib/protein/apis/server_api.ex
@@ -17,10 +17,10 @@ defmodule Protein.ServerAPI do
       transport layer) or nil (for non-responding services).
       """
       def process(request) do
-        {service_name, request_buf} = RequestPayload.decode(request)
+        {service_name, request_buf, request_metadata} = RequestPayload.decode(request)
         service_opts = __MODULE__.__service_opts__(service_name)
 
-        Server.process(request_buf, service_opts)
+        Server.process(request_buf, request_metadata, service_opts)
       end
     end
   end

--- a/lib/protein/payloads/request_payload.ex
+++ b/lib/protein/payloads/request_payload.ex
@@ -1,20 +1,32 @@
 defmodule Protein.RequestPayload do
   @moduledoc false
+  alias Protein.Utils
 
-  def encode(service_name, request_buf) do
+  def encode(service_name, request_buf, request_metadata) do
     Poison.encode!(%{
       "service_name" => service_name,
+      "request_metadata" => request_metadata,
       "request_buf_b64" => Base.encode64(request_buf),
     })
   end
 
   def decode(payload) do
-    %{
-      "service_name" => service_name,
-      "request_buf_b64" => request_buf_b64,
-    } = Poison.decode!(payload)
+    {service_name, request_buf_b64, request_metadata} = case Poison.decode!(payload) do
+      %{
+        "service_name" => service_name,
+        "request_metadata" => request_metadata,
+        "request_buf_b64" => request_buf_b64,
+      } ->
+        {service_name, request_buf_b64, request_metadata}
+      %{
+        "service_name" => service_name,
+        "request_buf_b64" => request_buf_b64,
+      } ->
+        {service_name, request_buf_b64, %{}}
+    end
     request_buf = Base.decode64!(request_buf_b64)
+    atomic_keys_request_metadata = Utils.atomize_map_keys(request_metadata)
 
-    {service_name, request_buf}
+    {service_name, request_buf, atomic_keys_request_metadata}
   end
 end

--- a/lib/protein/utils.ex
+++ b/lib/protein/utils.ex
@@ -31,4 +31,19 @@ defmodule Protein.Utils do
   def resolve_adapter_connection_mod(adapter_mod) do
     :"#{adapter_mod}.Connection"
   end
+
+  def generate_random_id do
+    binary = <<
+      System.system_time(:nanoseconds)::64,
+      :erlang.phash2({node(), self()}, 16_777_216)::24,
+      :erlang.unique_integer()::32
+    >>
+
+    Base.hex_encode32(binary, case: :lower)
+  end
+
+  def atomize_map_keys(map) do
+    map
+      |> Map.new(fn {key, value} -> {String.to_atom(key), value} end)
+  end
 end

--- a/test/protein/payloads/request_payload_test.exs
+++ b/test/protein/payloads/request_payload_test.exs
@@ -1,0 +1,39 @@
+defmodule Protein.RequestPayloadTest do
+  use ExUnit.Case
+  alias Protein.RequestPayload
+
+  describe "decode/1" do
+    test "decode with metadata" do
+      payload = Poison.encode!(%{
+        "service_name" => "TestService",
+        "request_metadata" => %{
+          timestamp: 1,
+          request_id: "qwerty12345"
+        },
+        "request_buf_b64" => Base.encode64("Request buffer")
+      })
+
+      {service_name, request_buf, request_metadata} = RequestPayload.decode(payload)
+
+      assert service_name == "TestService"
+      assert request_buf == "Request buffer"
+      assert request_metadata == %{
+        timestamp: 1,
+        request_id: "qwerty12345"
+      }
+    end
+
+    test "decode without metadata" do
+      payload = Poison.encode!(%{
+        "service_name" => "TestService",
+        "request_buf_b64" => Base.encode64("Request buffer")
+      })
+
+      {service_name, request_buf, request_metadata} = RequestPayload.decode(payload)
+
+      assert service_name == "TestService"
+      assert request_buf == "Request buffer"
+      assert request_metadata == %{}
+    end
+  end
+end

--- a/test/protein/payloads/response_payload_test.exs
+++ b/test/protein/payloads/response_payload_test.exs
@@ -1,22 +1,85 @@
 defmodule Protein.ResponsePayloadTest do
   use ExUnit.Case, async: true
-
   alias Protein.ResponsePayload
 
   describe "encode/1" do
     test "encode success" do
       response = "asdasd"
       encoded = Base.encode64(response)
-      assert ResponsePayload.encode({:ok, response}) ==  ~s({"response_buf_b64":"#{encoded}"})
+      assert ResponsePayload.encode({:ok, response, nil}) ==  ~s({"response_metadata":null,"response_buf_b64":"#{encoded}"})
     end
 
     test "encode error" do
       errors = [
         {:some_reason, pointer_type: :pointer_key}
       ]
-      expected_encoding = ~s({"errors":[{"reason":":some_reason",) <>
+      expected_encoding = ~s({"response_metadata":null,"errors":[{"reason":":some_reason",) <>
         ~s("pointer":[["pointer_type","pointer_key"]]}]})
-      assert ResponsePayload.encode({:error, errors}) == expected_encoding
+      assert ResponsePayload.encode({:error, errors, nil}) == expected_encoding
+    end
+  end
+
+  describe "decode/1" do
+    test "decode with metadata" do
+      payload = Poison.encode!(%{
+        "response_metadata" => %{
+          timestamp: 1,
+          request_id: "qwerty12345"
+        },
+        "response_buf_b64" => Base.encode64("Response buffer")
+      })
+
+      {status, response_buf, response_metadata} = ResponsePayload.decode(payload)
+
+      assert status == :ok
+      assert response_buf == "Response buffer"
+      assert response_metadata == %{
+        timestamp: 1,
+        request_id: "qwerty12345"
+      }
+    end
+
+    test "decode without metadata" do
+      payload = Poison.encode!(%{
+        "response_buf_b64" => Base.encode64("Response buffer")
+      })
+
+      {status, response_buf, response_metadata} = ResponsePayload.decode(payload)
+
+      assert status == :ok
+      assert response_buf == "Response buffer"
+      assert response_metadata == %{}
+    end
+
+    test "decode error with metadata" do
+      payload = Poison.encode!(%{
+        "errors" => [%{"reason" => "Error reason"}],
+        "response_metadata" => %{
+          timestamp: 1,
+          request_id: "qwerty12345"
+        },
+      })
+
+      {status, error_reason, response_metadata} = ResponsePayload.decode(payload)
+
+      assert status == :error
+      assert error_reason == [{"Error reason", nil}]
+      assert response_metadata == %{
+        timestamp: 1,
+        request_id: "qwerty12345"
+      }
+    end
+
+    test "decode error without metadata" do
+      payload = Poison.encode!(%{
+        "errors" => [%{"reason" => "Error reason"}]
+      })
+
+      {status, error_reason, response_metadata} = ResponsePayload.decode(payload)
+
+      assert status == :error
+      assert error_reason == [{"Error reason", nil}]
+      assert response_metadata == %{}
     end
   end
 end

--- a/test/protein/server_test.exs
+++ b/test/protein/server_test.exs
@@ -1,0 +1,64 @@
+defmodule Protein.ServerTest do
+  use ExUnit.Case, async: true
+  alias Protein.Server
+  alias Protein.SampleClient.{
+    CreateUser,
+    CreateUserMock
+  }
+
+  describe "process/1" do
+    test "process with response" do
+      encoded_request = CreateUser.Request.encode(
+        %CreateUser.Request{
+          user: %CreateUser.Request.User{
+            name: "Mary",
+            gender: :FEMALE
+          }
+        }
+      )
+
+      service_opts = [
+        service_name: "create_name",
+        service_mod: CreateUserMock,
+        request_mod: CreateUser.Request,
+        response_mod: CreateUser.Response
+      ]
+
+      expected_response = %CreateUser.Response{
+        user: %CreateUser.Response.User{
+          id: 1,
+          admin: false,
+          name: "Mary"
+        }
+      }
+
+      encoded_response = expected_response
+        |> CreateUser.Response.encode()
+        |> Base.encode64()
+
+      expected_result = ~r/^{"response_metadata":{"timestamp":\d+,"request_id":null},"response_buf_b64":"#{encoded_response}"}$/
+
+      assert Regex.match?(expected_result, Server.process(encoded_request, %{}, service_opts))
+    end
+
+    test "process without response" do
+      encoded_request = CreateUser.Request.encode(
+        %CreateUser.Request{
+          user: %CreateUser.Request.User{
+            name: "Jane",
+            gender: :FEMALE
+          }
+        }
+      )
+
+      service_opts = [
+        service_name: "create_name",
+        service_mod: CreateUserMock,
+        request_mod: CreateUser.Request,
+        response_mod: nil
+      ]
+
+      assert is_nil(Server.process(encoded_request, %{}, service_opts))
+    end
+  end
+end


### PR DESCRIPTION
## Overview
This pull request enables passing request metadata with the original contents for logging purposes. By default, `request_id` and `timestamp` are passed to logged rows as context. Unless `request_id` is passed from client service, it will be automatically generated before sending request.