### PR TITLE
Implement graceful shutdown for AMQP adapter

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,4 +3,11 @@ use Mix.Config
 if Mix.env() == :test do
   config :logger, level: :info
   config :protein, mocking_enabled: true
+  config :protein, serve: true
+
+  config :protein, Protein.EmptyServer,
+    transport: [adapter: :amqp, queue: "test", url: "amqp://test:test@localhost"]
+
+  config :protein, Protein.EmptyClient,
+    transport: [adapter: :amqp, queue: "test", url: "amqp://test:test@localhost"]
 end

--- a/lib/protein/adapters/amqp_adapter/server.ex
+++ b/lib/protein/adapters/amqp_adapter/server.ex
@@ -12,22 +12,37 @@ defmodule Protein.AMQPAdapter.Server do
   end
 
   def init(opts) do
+    Process.flag(:trap_exit, true)
     chan = connect(opts)
-    {:ok, {chan, opts}}
+    {:ok, {chan, opts, 0}}
+  end
+
+  def terminate(_reason, {_chan, _opts, running_processes_count}) do
+    wait_for_all_processes(running_processes_count)
+  end
+
+  def wait_for_all_processes(0), do: :ok
+
+  def wait_for_all_processes(running_processes_count) do
+    receive do
+      :process_finished -> wait_for_all_processes(running_processes_count - 1)
+      _ -> wait_for_all_processes(running_processes_count)
+    end
   end
 
   def handle_info({:basic_consume_ok, _meta}, state), do: {:noreply, state}
   def handle_info({:basic_cancel, _meta}, state), do: {:stop, :normal, state}
   def handle_info({:basic_cancel_ok, _meta}, state), do: {:noreply, state}
 
-  def handle_info({:basic_deliver, payload, meta}, state = {chan, opts}) do
-    spawn(fn -> consume(chan, opts, meta, payload) end)
-    {:noreply, state}
+  def handle_info({:basic_deliver, payload, meta}, {chan, opts, processes}) do
+    parent_pid = self()
+    spawn(fn -> consume(chan, opts, meta, payload, parent_pid) end)
+    {:noreply, {chan, opts, processes + 1}}
   end
 
   def handle_info({:DOWN, _, :process, _pid, _reason}, {_, opts}) do
     chan = connect(opts)
-    {:noreply, {chan, opts}}
+    {:noreply, {chan, opts, 0}}
   end
 
   defp connect(opts) do
@@ -77,7 +92,7 @@ defmodule Protein.AMQPAdapter.Server do
     end
   end
 
-  defp consume(chan, opts, meta, payload) do
+  defp consume(chan, opts, meta, payload, parent_pid) do
     server_mod = Keyword.fetch!(opts, :server_mod)
 
     {response, error} = try_process(payload, server_mod)
@@ -85,6 +100,7 @@ defmodule Protein.AMQPAdapter.Server do
     if should_respond(response, meta), do: respond(response, chan, meta)
 
     Basic.ack(chan, meta.delivery_tag)
+    send(parent_pid, :process_finished)
 
     if error do
       {exception, stacktrace} = error

--- a/lib/protein/server.ex
+++ b/lib/protein/server.ex
@@ -150,7 +150,13 @@ defmodule Protein.Server do
 
         transport_server_opts = Keyword.put(transport_opts, :server_mod, __MODULE__)
 
-        [{transport_server_mod, transport_server_opts}]
+        [
+          %{
+            id: transport_server_mod,
+            start: {transport_server_mod, :start_link, [transport_server_opts]},
+            shutdown: 15_000
+          }
+        ]
       end
     end
   end

--- a/lib/protein/server.ex
+++ b/lib/protein/server.ex
@@ -150,13 +150,7 @@ defmodule Protein.Server do
 
         transport_server_opts = Keyword.put(transport_opts, :server_mod, __MODULE__)
 
-        [
-          %{
-            id: transport_server_mod,
-            start: {transport_server_mod, :start_link, [transport_server_opts]},
-            shutdown: 15_000
-          }
-        ]
+        [{transport_server_mod, transport_server_opts}]
       end
     end
   end

--- a/test/protein/server_test.exs
+++ b/test/protein/server_test.exs
@@ -1,0 +1,61 @@
+defmodule Protein.ServerTest do
+  use ExUnit.Case, async: false
+  @moduletag :external
+
+  alias Mix.Config
+
+  alias Protein.{
+    EmptyClient,
+    EmptyServer
+  }
+
+  describe "start_link/1" do
+    test "success" do
+      Config.persist(
+        protein: [
+          mocking_enabled: false
+        ]
+      )
+
+      {:ok, server_pid} = EmptyServer.start_link()
+      {:ok, _client_pid} = EmptyClient.start_link()
+
+      request = %EmptyClient.Empty.Request{}
+
+      parent = self()
+
+      spawn(fn ->
+        Process.flag(:trap_exit, true)
+        response = EmptyClient.call(request)
+        send(parent, response)
+      end)
+
+      # wait for server to start processing
+      :timer.sleep(50)
+
+      try do
+        Process.flag(:trap_exit, true)
+        Process.exit(server_pid, :shutdown)
+
+        receive do
+          {:EXIT, _pid, _error} -> :ok
+        end
+      rescue
+        e in RuntimeError -> e
+      end
+
+      Process.flag(:trap_exit, false)
+
+      receive do
+        response ->
+          assert {:ok, %Protein.EmptyClient.Empty.Response{}} == response
+      end
+    after
+      Config.persist(
+        protein: [
+          mocking_enabled: true
+        ]
+      )
+    end
+  end
+end

--- a/test/support/protein/empty_client.ex
+++ b/test/support/protein/empty_client.ex
@@ -1,0 +1,7 @@
+defmodule Protein.EmptyClient do
+  @moduledoc false
+
+  use Protein.Client
+
+  proto(:empty)
+end

--- a/test/support/protein/empty_server.ex
+++ b/test/support/protein/empty_server.ex
@@ -1,0 +1,14 @@
+defmodule Protein.EmptyServer do
+  @moduledoc false
+
+  use Protein.Server
+
+  proto(:empty)
+end
+
+defmodule Protein.EmptyServer.EmptyService do
+  def call(_request) do
+    :timer.sleep(100)
+    :ok
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+ExUnit.configure(exclude: [external: true])
 ExUnit.start()


### PR DESCRIPTION
Wait for all active server request to complete when using AMQP adapter.