### PR TITLE
Run AMQP adapter server as supervisor

### DIFF
--- a/lib/protein/adapters/amqp_adapter/server.ex
+++ b/lib/protein/adapters/amqp_adapter/server.ex
@@ -2,7 +2,7 @@ defmodule Protein.AMQPAdapter.Server do
   @moduledoc false
 
   use AMQP
-  use GenServer
+  use GenServer, type: :supervisor
   require Logger
   alias AMQP.{Basic, Channel, Connection, Queue}
   alias Protein.Utils


### PR DESCRIPTION
Currently AMQPAdapter.Server is running as worker which has shutdown default at 5 seconds. We need it to run as supervisor so main application can decide what the shutdown timeout should be.