### PR TITLE
Handle DOWN message in AMQP adapter

### DIFF
--- a/lib/protein/adapters/amqp_adapter/server.ex
+++ b/lib/protein/adapters/amqp_adapter/server.ex
@@ -40,9 +40,16 @@ defmodule Protein.AMQPAdapter.Server do
     {:noreply, {chan, opts, processes + 1}}
   end
 
-  def handle_info({:DOWN, _, :process, _pid, _reason}, {_, opts}) do
+  def handle_info(
+        {:DOWN, _, :process, pid, _reason},
+        {%Channel{conn: %Connection{pid: pid}}, opts, _}
+      ) do
     chan = connect(opts)
     {:noreply, {chan, opts, 0}}
+  end
+
+  def handle_info({:DOWN, _, :process, _pid, :normal}, {chan, opts, count}) do
+    {:noreply, {chan, opts, count - 1}}
   end
 
   defp connect(opts) do


### PR DESCRIPTION
Now, two type of processes are monitored in AMQP adapter: AMQP connection and processes that perform work. We need to distinguish which one sends DOWN message.