### PR TITLE
Listen for :DOWN signal from error in monitored process

### DIFF
--- a/lib/protein/adapters/amqp_adapter/server.ex
+++ b/lib/protein/adapters/amqp_adapter/server.ex
@@ -48,7 +48,8 @@ defmodule Protein.AMQPAdapter.Server do
     {:noreply, {chan, opts, 0}}
   end
 
-  def handle_info({:DOWN, _, :process, _pid, :normal}, {chan, opts, count}) do
+  # handles normal exit and error
+  def handle_info({:DOWN, _, :process, _pid, _reason}, {chan, opts, count}) do
     {:noreply, {chan, opts, count - 1}}
   end
 

--- a/test/support/protein/empty_client.ex
+++ b/test/support/protein/empty_client.ex
@@ -4,4 +4,5 @@ defmodule Protein.EmptyClient do
   use Protein.Client
 
   proto(:empty)
+  proto(:error)
 end

--- a/test/support/protein/empty_server.ex
+++ b/test/support/protein/empty_server.ex
@@ -4,11 +4,18 @@ defmodule Protein.EmptyServer do
   use Protein.Server
 
   proto(:empty)
+  proto(:error)
 end
 
 defmodule Protein.EmptyServer.EmptyService do
   def call(_request) do
     :timer.sleep(100)
     :ok
+  end
+end
+
+defmodule Protein.EmptyServer.ErrorService do
+  def call(_request) do
+    raise "oops"
   end
 end

--- a/test/support/protein/proto/error.proto
+++ b/test/support/protein/proto/error.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package error;
+
+message Request {
+}
+
+message Response {
+}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,19 @@
 ExUnit.configure(exclude: [external: true])
 ExUnit.start()
+
+defmodule TestUtil do
+  def stop_process(pid) do
+    try do
+      Process.flag(:trap_exit, true)
+      Process.exit(pid, :shutdown)
+
+      receive do
+        {:EXIT, _pid, _error} -> :ok
+      end
+    rescue
+      e in RuntimeError -> e
+    end
+
+    Process.flag(:trap_exit, false)
+  end
+end


### PR DESCRIPTION
It fixes problem when :DOWN signal was not captured by protein and process was not usable when rpc service throwed an error.
Current master has this error and this fixes an issue.