### PR TITLE
One line request logs

### DIFF
--- a/lib/protein/server.ex
+++ b/lib/protein/server.ex
@@ -219,8 +219,6 @@ defmodule Protein.Server do
   end
 
   defp log_process(kind, service_name, process_func) do
-    Logger.info(fn -> "Processing RPC #{kind}: #{service_name}" end)
-
     start_time = :os.system_time(:millisecond)
     result = process_func.()
     duration_ms = :os.system_time(:millisecond) - start_time
@@ -232,7 +230,7 @@ defmodule Protein.Server do
         {:call, _} -> "Rejected"
       end
 
-    Logger.info(fn -> "#{status_text} in #{duration_ms}ms" end)
+    Logger.info(fn -> "RPC #{kind} #{service_name} #{status_text} in #{duration_ms}ms" end)
 
     result
   end


### PR DESCRIPTION
Multi line logs make log reading or querying for stats quite hard, the new format make it slightly better.
This bring logs in line with ruby implementation: https://github.com/surgeventures/protein-ruby/pull/11

Old format:
```
[2019-06-28T12:48:38.045573 #34] INFO -- protein: Processing RPC call: some_action
[2019-06-28T12:48:38.113198 #54] INFO -- protein: Processing RPC call: another_action
[2019-06-28T12:48:38.083760 #34] INFO -- protein: Resolved in 38ms
[2019-06-28T12:48:38.176725 #37] INFO -- protein: Processing RPC call: another_action
[2019-06-28T12:48:38.197275 #55] INFO -- protein: Processing RPC call: another_action
[2019-06-28T12:48:38.244510 #37] INFO -- protein: Resolved in 68ms
[2019-06-28T12:48:38.262265 #55] INFO -- protein: Resolved in 65ms
[2019-06-28T12:48:38.127635 #57] INFO -- protein: Processing RPC call: more_actions
[2019-06-28T12:48:38.195192 #57] INFO -- protein: Resolved in 67ms
[2019-06-28T12:48:38.212175 #54] INFO -- protein: Resolved in 99ms
```
New Format: 
```
[2019-06-28T12:48:38.083760 #34] INFO -- protein: RPC call some_action resolved in 38ms
[2019-06-28T12:48:38.244510 #37] INFO -- protein: RPC call another_action resolved in 68ms
[2019-06-28T12:48:38.262265 #55] INFO -- protein: RPC call another_action resolved in 65ms
[2019-06-28T12:48:38.195192 #57] INFO -- protein: RPC call more_actions resolved in 67ms
[2019-06-28T12:48:38.212175 #54] INFO -- protein: RPC call another_action resolved in 99ms
```